### PR TITLE
File 'ol.css' is missing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
                                     <fileset dir="${project.build.directory}/v${upstream.version}/build" />
+                                    <fileset dir="${project.build.directory}/v${upstream.version}/css" />
                                 </move>
                             </target>
                         </configuration>


### PR DESCRIPTION
A required stylesheet is missing from this webjar. Trying to instantiate OpenLayers without it results in a broken user interface.
